### PR TITLE
fix: shorten Makefile and cleanup *.tex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,16 @@
 # 	Makefile for compiling assignment latex template	\
-	Dependencies: [texlive(full),inkscape]
+	Dependencies: [texlive(full)]
 
-TEXSRC = $(shell find . -name "*.tex")
-TEXSRC += $(shell find . -name "*.bib")
-TEXBUILD := build
-TEXCOMPILE := latexmk -pdf
-BIBCOMPILE := bibtex
-TEXNAME := template
-OUTNAME := template
-TEXFLAGS := -interaction=nonstopmode -output-directory=$(TEXBUILD) -file-line-error
-TEXFILES := acn acr alg aux bbl blg def defdvi fdb_latexmk fls glg glo gls ist lof log lot out synctex.gz toc 
+SRC := $(shell find . -name '*.tex')
+TARGET := $(patsubst %.tex,%.pdf,$(SRC))
+BUILD_DIR := ./build
 
 .PHONY: all clean
-all: $(TEXSRC)
-	@mkdir -p $(TEXBUILD)
-	@$(TEXCOMPILE) $(TEXFLAGS) $(TEXNAME).tex
-	@for aux in $(shell find . -name "*.aux"); do $(BIBCOMPILE) $$aux;  done
-	@mv $(TEXBUILD)/$(TEXNAME).pdf $(OUTNAME).pdf
+all:
+	@mkdir -p $(BUILD_DIR)
+	latexmk -pdf -interaction=nonstopmode -output-directory=$(BUILD_DIR) -file-line-error $(SRC)
+	@mv $(BUILD_DIR)/$(notdir $(TARGET)) $(TARGET)
 
 clean:
-	@rm -rf $(TEXBUILD) $(addsuffix .pdf, ${TEXNAME} ${OUTNAME}) $(addprefix *., ${TEXFILES})
+	latexmk -c $(SRC)
+

--- a/template.tex
+++ b/template.tex
@@ -9,7 +9,6 @@
 \usepackage{url}
 \usepackage{verbatim}
 \usepackage{graphicx}
-% \usepackage{svg}
 \usepackage{booktabs,threeparttable}
 \hyphenation{op-tical net-works semi-conduc-tor IEEE-Xplore}
 % updated with editorial comments 8/9/2021
@@ -160,6 +159,7 @@ The following snippet shows how to import figures.
 	\label{fig:block_diagram}
 \end{figure}
 
+% NOTE: Requires \usepackage{svg} and Inkscape installed
 % \begin{figure}[htbp]
 % 	\centering
 % 	\includegraphics[scale=0.5]{figures/NVSD_VDD_IN.svg}
@@ -272,8 +272,6 @@ Here you sum up the report and reiterate the results. Does not need to be very l
 	If you have multiple appendixes use $\backslash${\tt{appendices}} then use $\backslash${\tt{section}} to start each appendix.
 	You must declare a $\backslash${\tt{section}} before using any $\backslash${\tt{subsection}} or using $\backslash${\tt{label}} ($\backslash${\tt{appendices}} by itself
 	starts a section numbered zero.)}
-
-
 
 %{\appendices
 %\section*{Proof of the First Zonklar Equation}

--- a/template.tex
+++ b/template.tex
@@ -162,7 +162,7 @@ The following snippet shows how to import figures.
 % NOTE: Requires \usepackage{svg} and Inkscape installed
 % \begin{figure}[htbp]
 % 	\centering
-% 	\includegraphics[scale=0.5]{figures/NVSD_VDD_IN.svg}
+% 	\includesvg[scale=0.5]{figures/NVSD_VDD_IN.svg}
 % 	\caption{Total power consumption compared between NAS and SD-Card\newline \emph{Note} the NAS-experiment did not complete in time, and the measurements for the NAS fit to the SD-card measurements}
 % 	\label{fig:local_nas_sd_compare}
 % \end{figure}


### PR DESCRIPTION
Removes some of the unnecessary Makefile commands.

Add note regarding use of `*.svg` files for figures. 