### PR TITLE
Separate CI and move docs to root

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,4 +18,4 @@ jobs:
         uses: xu-cheng/latex-action@v2
         with:
           root_file: src/template.tex
-          args: -pdf -shell-escape -interaction=nonstopmode -output-directory=build
+          args: -pdf -shell-escape -interaction=nonstopmode -output-directory=.build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,5 +17,5 @@ jobs:
       - name: Compile LaTeX document
         uses: xu-cheng/latex-action@v2
         with:
-          root_file: template.tex
+          root_file: src/template.tex
           args: -pdf -shell-escape -interaction=nonstopmode -output-directory=build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Build pdf
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: template.tex
+          args: -pdf -shell-escape -interaction=nonstopmode -output-directory=build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build and release thesis
+name: Build and release pdf
 
 on:
   push:
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  build-pdf:
+  release-pdf:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ The project uses GitHub Actions to build the LaTeX document and create a release
 
 ## Credits
 
-This template is using the [IEEE-Tran](https://www.ieee.org/conferences/publishing/templates.html) `cls` file.
+This template is using the [IEEEtran](https://www.ieee.org/conferences/publishing/templates.html) `cls` file.


### PR DESCRIPTION
# CI

Separate the CI-workflow into `build` and `release`, in order to run `build` on all PRs as a merge-check/condition.

# Docs

Move a copy of the `README` to the root, for increased usability as a GitHub Repo.